### PR TITLE
Refactor CLI mods parsing into helper

### DIFF
--- a/fast_trade/cli.py
+++ b/fast_trade/cli.py
@@ -12,7 +12,7 @@ from fast_trade.archive.cli import download_asset, get_assets
 from fast_trade.archive.update_archive import update_archive
 from fast_trade.validate_backtest import validate_backtest
 
-from .cli_helpers import create_plot, open_strat_file, save
+from .cli_helpers import _apply_mods, create_plot, open_strat_file, save
 from .run_backtest import run_backtest
 
 parser = argparse.ArgumentParser(
@@ -109,14 +109,7 @@ def backtest_helper(*args, **kwargs):
     if not strat_obj:
         print("Could not open strategy file: {}".format(kwargs.get("strategy")))
         sys.exit(1)
-    if kwargs.get("mods"):
-        mods = {}
-        i = 0
-        while i < len(kwargs.get("mods")):
-            mods[kwargs.get("mods")[i]] = kwargs.get("mods")[i + 1]
-            i += 2
-
-        strat_obj = {**strat_obj, **mods}
+    strat_obj = _apply_mods(strat_obj, kwargs.get("mods"))
 
     result = run_backtest(strat_obj)
     summary = result.get("summary")
@@ -160,14 +153,7 @@ def backtest_helper(*args, **kwargs):
 
 def validate_helper(args):
     strat_obj = open_strat_file(args.get("strategy"))
-    if args.get("mods"):
-        mods = {}
-        i = 0
-        while i < len(args.get("mods")):
-            mods[args.get("mods")[i]] = args.get("mods")[i + 1]
-            i += 2
-
-        strat_obj = {**strat_obj, **mods}
+    strat_obj = _apply_mods(strat_obj, args.get("mods"))
 
     validate_backtest(strat_obj)
 

--- a/fast_trade/cli_helpers.py
+++ b/fast_trade/cli_helpers.py
@@ -41,6 +41,21 @@ def open_strat_file(fp):
         raise MissingStrategyFile("Could not open strategy file at path: {}".format(fp))
 
 
+def _apply_mods(strat_obj, mods_args):
+    """Return a new strategy dictionary with CLI modifiers applied."""
+
+    if not mods_args:
+        return strat_obj
+
+    mods = {}
+    i = 0
+    while i < len(mods_args):
+        mods[mods_args[i]] = mods_args[i + 1]
+        i += 2
+
+    return {**strat_obj, **mods}
+
+
 def create_plot(df, trade_df, show_plot=True):
     # Filter for numeric columns only
     numeric_df = df.select_dtypes(include=["number"])


### PR DESCRIPTION
## Summary
- add a shared `_apply_mods` helper for applying CLI modifier arguments
- update the backtest and validate helpers to use the shared modifier parser

## Testing
- `pytest` *(fails: missing third-party dependencies such as pandas and numpy in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe0f543148331895b5c008c1bfb2d